### PR TITLE
Add service quota policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,9 @@
 
 [![GitHub Build Status](https://github.com/cisagov/provisionaccount-role-tf-module/workflows/build/badge.svg)](https://github.com/cisagov/provisionaccount-role-tf-module/actions)
 
-This is a generic skeleton project that can be used to quickly get a
-new [cisagov](https://github.com/cisagov) [Terraform
-module](https://www.terraform.io/docs/modules/index.html) GitHub
-repository started.  This skeleton project contains [licensing
-information](LICENSE), as well as [pre-commit
-hooks](https://pre-commit.com) and
-[GitHub Actions](https://github.com/features/actions) configurations
-appropriate for the major languages that we use.
-
-See [here](https://www.terraform.io/docs/modules/index.html) for more
-details on Terraform modules and the standard module structure.
+A Terraform module to create an AWS IAM role with permissions to provision
+any IAM resources in an AWS account, and trust a different AWS account so
+that the role can be assumed via IAM.
 
 ## Usage ##
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ No modules.
 |------|------|
 | [aws_iam_role.provisionaccount_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.iamfullaccess_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.servicequotasfullaccess_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_policy_document.assume_role_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs ##

--- a/provision_role.tf
+++ b/provision_role.tf
@@ -13,3 +13,9 @@ resource "aws_iam_role_policy_attachment" "iamfullaccess_policy_attachment" {
   policy_arn = "arn:aws:iam::aws:policy/IAMFullAccess"
   role       = aws_iam_role.provisionaccount_role.name
 }
+
+# This policy allows us to request changes to default service quotas
+resource "aws_iam_role_policy_attachment" "servicequotasfullaccess_policy_attachment" {
+  policy_arn = "arn:aws:iam::aws:policy/ServiceQuotasFullAccess"
+  role       = aws_iam_role.provisionaccount_role.name
+}


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds the standard AWS `ServiceQuotasFullAccess` policy to the account provisioning role that this module creates.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We want to automate our service quota requests when we obtain new AWS accounts, so this new policy will be utilized then.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I pointed my [`cool-accounts/dynamic`](https://github.com/cisagov/cool-accounts/blob/develop/dynamic/provisionaccount.tf#L2) Terraform at this branch and applied it in a test environment.  I confirmed that the resulting `ProvisionAccount` role did indeed include the `ServiceQuotasFullAccess` policy.
 
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
