### PR TITLE
Add policy to allow creation and subscription to an SNS topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ No modules.
 | provisionaccount\_role\_description | The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the new account (e.g. "Allows sufficient permissions to provision all AWS resources in the DNS account."). | `string` | n/a | yes |
 | provisionaccount\_role\_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the new account (e.g. "ProvisionAccount"). | `string` | n/a | yes |
 | sns\_policy\_description | The description to associate with the IAM policy that allows sufficient permissions to create and subscribe to a generic notification topic for CloudWatch alarms in the new account. | `string` | `"Allows sufficient permissions to create and subscribe to a generic notification topic for CloudWatch alarms in the new account."` | no |
-| sns\_policy\_name | The name to assign with the IAM policy that allows sufficient permissions to create and subscribe to a generic notification topic for CloudWatch alarms in the new account. | `string` | `"CWAlarmSNSTopicPolicy"` | no |
+| sns\_policy\_name | The name to assign the IAM policy that allows sufficient permissions to create and subscribe to a generic notification topic for CloudWatch alarms in the new account. | `string` | `"CWAlarmSNSTopicPolicy"` | no |
 | users\_account\_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the new account. | `string` | n/a | yes |
 
 ## Outputs ##

--- a/README.md
+++ b/README.md
@@ -43,10 +43,13 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_iam_policy.sns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.provisionaccount_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.iamfullaccess_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.servicequotasfullaccess_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.sns_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_policy_document.assume_role_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.sns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs ##
 
@@ -55,6 +58,8 @@ No modules.
 | aws\_region | The AWS region where the non-global resources for the new account are to be provisioned (e.g. "us-east-1"). | `string` | `"us-east-1"` | no |
 | provisionaccount\_role\_description | The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the new account (e.g. "Allows sufficient permissions to provision all AWS resources in the DNS account."). | `string` | n/a | yes |
 | provisionaccount\_role\_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the new account (e.g. "ProvisionAccount"). | `string` | n/a | yes |
+| sns\_policy\_description | The description to associate with the IAM policy that allows sufficient permissions to create and subscribe to a generic notification topic for CloudWatch alarms in the new account. | `string` | `"Allows sufficient permissions to create and subscribe to a generic notification topic for CloudWatch alarms in the new account."` | no |
+| sns\_policy\_name | The name to assign with the IAM policy that allows sufficient permissions to create and subscribe to a generic notification topic for CloudWatch alarms in the new account. | `string` | `"CWAlarmSNSTopicPolicy"` | no |
 | users\_account\_id | The ID of the users account.  This account will be allowed to assume the role that allows sufficient permissions to provision all AWS resources in the new account. | `string` | n/a | yes |
 
 ## Outputs ##

--- a/provision_role.tf
+++ b/provision_role.tf
@@ -19,3 +19,9 @@ resource "aws_iam_role_policy_attachment" "servicequotasfullaccess_policy_attach
   policy_arn = "arn:aws:iam::aws:policy/ServiceQuotasFullAccess"
   role       = aws_iam_role.provisionaccount_role.name
 }
+
+# This policy allows us to create and subscribe to SNS topics
+resource "aws_iam_role_policy_attachment" "sns_policy_attachment" {
+  policy_arn = aws_iam_policy.sns.arn
+  role       = aws_iam_role.provisionaccount_role.name
+}

--- a/sns_policy.tf
+++ b/sns_policy.tf
@@ -1,0 +1,27 @@
+# ------------------------------------------------------------------------------
+# Create the IAM policy that allows all of the SNS actions necessary
+# to create and subscribe to a generic notification topic for
+# CloudWatch alarms in this account.
+# ------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "sns" {
+  statement {
+    actions = [
+      "sns:CreateTopic",
+      "sns:DeleteTopic",
+      "sns:GetSubscriptionAttributes",
+      "sns:GetTopicAttributes",
+      "sns:SetTopicAttributes",
+      "sns:Subscribe",
+      "sns:Unsubscribe",
+    ]
+    resources = ["*"]
+  }
+
+}
+
+resource "aws_iam_policy" "sns" {
+  description = var.sns_policy_description
+  name        = var.sns_policy_name
+  policy      = data.aws_iam_policy_document.sns.json
+}

--- a/variables.tf
+++ b/variables.tf
@@ -32,7 +32,7 @@ variable "sns_policy_description" {
 
 variable "sns_policy_name" {
   type        = string
-  description = "The name to assign with the IAM policy that allows sufficient permissions to create and subscribe to a generic notification topic for CloudWatch alarms in the new account."
+  description = "The name to assign the IAM policy that allows sufficient permissions to create and subscribe to a generic notification topic for CloudWatch alarms in the new account."
   default     = "CWAlarmSNSTopicPolicy"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -24,6 +24,18 @@ variable "users_account_id" {
 #
 # These parameters have reasonable defaults.
 # ------------------------------------------------------------------------------
+variable "sns_policy_description" {
+  type        = string
+  description = "The description to associate with the IAM policy that allows sufficient permissions to create and subscribe to a generic notification topic for CloudWatch alarms in the new account."
+  default     = "Allows sufficient permissions to create and subscribe to a generic notification topic for CloudWatch alarms in the new account."
+}
+
+variable "sns_policy_name" {
+  type        = string
+  description = "The name to assign with the IAM policy that allows sufficient permissions to create and subscribe to a generic notification topic for CloudWatch alarms in the new account."
+  default     = "CWAlarmSNSTopicPolicy"
+}
+
 variable "aws_region" {
   type        = string
   description = "The AWS region where the non-global resources for the new account are to be provisioned (e.g. \"us-east-1\")."


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a policy to allow creation and subscription to an SNS topic.  It also attaches the policy to the "ProvisionAccount" role being created in this repo.

## 💭 Motivation and context ##

These permissions are required for cisagov/cool-accounts#118.

## 🧪 Testing ##

All automated testing passes.  I also used these changes to create and subscribe to the CloudWatch alarm SNS topic in the COOL Audit account.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.