### PR TITLE
Add `sns:ListTagsForResource` to SNS policy

### DIFF
--- a/sns_policy.tf
+++ b/sns_policy.tf
@@ -11,6 +11,7 @@ data "aws_iam_policy_document" "sns" {
       "sns:DeleteTopic",
       "sns:GetSubscriptionAttributes",
       "sns:GetTopicAttributes",
+      "sns:ListTagsForResource",
       "sns:SetTopicAttributes",
       "sns:Subscribe",
       "sns:Unsubscribe",


### PR DESCRIPTION

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds the `sns:ListTagsForResource` permission to the SNS policy attached to the `ProvisionAccount` role.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This permission is required in certain cases.  I ran into it while attempting to [bootstrap the `cisagov/cool-accounts/master`](https://github.com/cisagov/cool-accounts/tree/develop/master#bootstrapping-this-account) account.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Visual inspection. 😄 

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

