### PR TITLE
Add permissions to create the new user alert resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,15 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_iam_policy.eventbridge](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.sns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.provisionaccount_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.eventbridge_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.iamfullaccess_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.servicequotasfullaccess_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.sns_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_policy_document.assume_role_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.eventbridge](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.sns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs ##
@@ -56,6 +59,8 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | aws\_region | The AWS region where the non-global resources for the new account are to be provisioned (e.g. "us-east-1"). | `string` | `"us-east-1"` | no |
+| eventbridge\_policy\_description | The description to associate with the IAM policy that allows sufficient permissions to create an EventBridge rule that is triggered whenever a new IAM or SSO user is created, as well as connect a target to that rule, in the new account. | `string` | `"Allows sufficient permissions to create an EventBridge rule that is triggered whenever a new IAM or SSO user is created, as well as connect a target to that rule, in the new account."` | no |
+| eventbridge\_policy\_name | The name to assign the IAM policy that allows sufficient permissions to create an EventBridge rule that is triggered whenever a new IAM or SSO user is created, as well as connect a target to that rule, in the new account. | `string` | `"NewUserEventBridgePolicy"` | no |
 | provisionaccount\_role\_description | The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the new account (e.g. "Allows sufficient permissions to provision all AWS resources in the DNS account."). | `string` | n/a | yes |
 | provisionaccount\_role\_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the new account (e.g. "ProvisionAccount"). | `string` | n/a | yes |
 | sns\_policy\_description | The description to associate with the IAM policy that allows sufficient permissions to create and subscribe to a generic notification topic for CloudWatch alarms in the new account. | `string` | `"Allows sufficient permissions to create and subscribe to a generic notification topic for CloudWatch alarms in the new account."` | no |

--- a/eventbridge_policy.tf
+++ b/eventbridge_policy.tf
@@ -1,0 +1,29 @@
+# ------------------------------------------------------------------------------
+# Create the IAM policy that allows all of the EventBridge actions
+# necessary to create an EventBridge rule that is triggered whenever a
+# new IAM or SSO user is created, as well as connect a target to that
+# rule.
+# ------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "eventbridge" {
+  statement {
+    actions = [
+      "events:DeleteRule",
+      "events:DescribeRule",
+      "events:ListTargetsByRule",
+      "events:PutRule",
+      "events:PutTargets",
+      "events:RemoveTargets",
+      "events:TagResource",
+      "events:UntagResource",
+    ]
+    resources = ["*"]
+  }
+
+}
+
+resource "aws_iam_policy" "eventbridge" {
+  description = var.eventbridge_policy_description
+  name        = var.eventbridge_policy_name
+  policy      = data.aws_iam_policy_document.eventbridge.json
+}

--- a/provision_role.tf
+++ b/provision_role.tf
@@ -25,3 +25,10 @@ resource "aws_iam_role_policy_attachment" "sns_policy_attachment" {
   policy_arn = aws_iam_policy.sns.arn
   role       = aws_iam_role.provisionaccount_role.name
 }
+
+# This policy allows us to create EventBridge event rules and connect
+# them to targets
+resource "aws_iam_role_policy_attachment" "eventbridge_policy_attachment" {
+  policy_arn = aws_iam_policy.eventbridge.arn
+  role       = aws_iam_role.provisionaccount_role.name
+}

--- a/variables.tf
+++ b/variables.tf
@@ -24,6 +24,18 @@ variable "users_account_id" {
 #
 # These parameters have reasonable defaults.
 # ------------------------------------------------------------------------------
+variable "eventbridge_policy_description" {
+  type        = string
+  description = "The description to associate with the IAM policy that allows sufficient permissions to create an EventBridge rule that is triggered whenever a new IAM or SSO user is created, as well as connect a target to that rule, in the new account."
+  default     = "Allows sufficient permissions to create an EventBridge rule that is triggered whenever a new IAM or SSO user is created, as well as connect a target to that rule, in the new account."
+}
+
+variable "eventbridge_policy_name" {
+  type        = string
+  description = "The name to assign the IAM policy that allows sufficient permissions to create an EventBridge rule that is triggered whenever a new IAM or SSO user is created, as well as connect a target to that rule, in the new account."
+  default     = "NewUserEventBridgePolicy"
+}
+
 variable "sns_policy_description" {
   type        = string
   description = "The description to associate with the IAM policy that allows sufficient permissions to create and subscribe to a generic notification topic for CloudWatch alarms in the new account."


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds additional permissions to create the new user alert resources.

## 💭 Motivation and context ##

We require these changes in order to create the new user alert resources.

## 🧪 Testing ##

All automated tests succeed.  I also applied these changes to the `audit` subdirectory of [cisagov/cool-accounts](https://github.com/cisagov/cool-accounts) and verified that I was able to create the new user alert resources.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Post-merge checklist ##

- [x] Apply these changes to all static COOL accounts.
