### PR TITLE
Add missing permissions to EventBridge and SNS policies

### DIFF
--- a/eventbridge_policy.tf
+++ b/eventbridge_policy.tf
@@ -10,6 +10,7 @@ data "aws_iam_policy_document" "eventbridge" {
     actions = [
       "events:DeleteRule",
       "events:DescribeRule",
+      "events:ListTagsForResource",
       "events:ListTargetsByRule",
       "events:PutRule",
       "events:PutTargets",

--- a/sns_policy.tf
+++ b/sns_policy.tf
@@ -14,6 +14,7 @@ data "aws_iam_policy_document" "sns" {
       "sns:ListTagsForResource",
       "sns:SetTopicAttributes",
       "sns:Subscribe",
+      "sns:TagResource",
       "sns:Unsubscribe",
     ]
     resources = ["*"]


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR:
 * Adds the `events:ListTagsForResource` permission to EventBridge policy included with this role
 * Adds the `sns:TagResource` permission to SNS policy included with this role

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

These permissions were overlooked previously.  I discovered they were missing when I attempted to apply the Terraform in `cool-accounts/users`.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I added these permissions manually in Production and verified that I was then able to successfully apply the Terraform in `cool-accounts/users`.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
