### PR TITLE
Add permissions necessary for cisagov/disable-inactive-iam-users-tf-module

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,17 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_iam_policy.eventbridge](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.sns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.provisionaccount_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.eventbridge_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.iamfullaccess_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.lambda_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.servicequotasfullaccess_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.sns_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_policy_document.assume_role_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.eventbridge](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.sns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs ##
@@ -60,8 +63,10 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | aws\_region | The AWS region where the non-global resources for the new account are to be provisioned (e.g. "us-east-1"). | `string` | `"us-east-1"` | no |
-| eventbridge\_policy\_description | The description to associate with the IAM policy that allows sufficient permissions to create an EventBridge rule that is triggered whenever a new IAM or SSO user is created, as well as connect a target to that rule, in the new account. | `string` | `"Allows sufficient permissions to create an EventBridge rule that is triggered whenever a new IAM or SSO user is created, as well as connect a target to that rule, in the new account."` | no |
-| eventbridge\_policy\_name | The name to assign the IAM policy that allows sufficient permissions to create an EventBridge rule that is triggered whenever a new IAM or SSO user is created, as well as connect a target to that rule, in the new account. | `string` | `"NewUserEventBridgePolicy"` | no |
+| eventbridge\_policy\_description | The description to associate with the IAM policy that allows sufficient permissions to create an EventBridge rule that is triggered whenever a new IAM or SSO user is created, as well as connect a target to that rule, in the new account.  This policy is also used to create an EventBridge rule that is run at a fixed cadence with a Lambda target that disables AWS access for inactive users. | `string` | `"Allows sufficient permissions to create an EventBridge rule that is triggered whenever a new IAM or SSO user is created, as well as connect a target to that rule, in the new account.  Also alows sufficient permissions to create an EventBridge rule that is run at a fixed cadence with a Lambda target that disables AWS access for inactive users."` | no |
+| eventbridge\_policy\_name | The name to assign the IAM policy that allows sufficient permissions to create an EventBridge rule that is triggered whenever a new IAM or SSO user is created, as well as connect a target to that rule, in the new account.  This policy is also used to create an EventBridge rule that is run at a fixed cadence with a Lambda target that disables AWS access for inactive users. | `string` | `"NewUserEventBridgePolicy"` | no |
+| lambda\_policy\_description | The description to associate with the IAM policy that allows sufficient permissions to create a Lambda function in the new account. | `string` | `"Allows sufficient permissions to create a Lambda function in the new account."` | no |
+| lambda\_policy\_name | The name to assign the IAM policy that allows sufficient permissions to create a Lambda function in the new account. | `string` | `"LambdaPolicy"` | no |
 | provisionaccount\_role\_description | The description to associate with the IAM role that allows sufficient permissions to provision all AWS resources in the new account (e.g. "Allows sufficient permissions to provision all AWS resources in the DNS account."). | `string` | n/a | yes |
 | provisionaccount\_role\_name | The name to assign the IAM role that allows sufficient permissions to provision all AWS resources in the new account (e.g. "ProvisionAccount"). | `string` | n/a | yes |
 | sns\_policy\_description | The description to associate with the IAM policy that allows sufficient permissions to create and subscribe to a generic notification topic for CloudWatch alarms in the new account. | `string` | `"Allows sufficient permissions to create and subscribe to a generic notification topic for CloudWatch alarms in the new account."` | no |

--- a/eventbridge_policy.tf
+++ b/eventbridge_policy.tf
@@ -3,6 +3,10 @@
 # necessary to create an EventBridge rule that is triggered whenever a
 # new IAM or SSO user is created, as well as connect a target to that
 # rule.
+#
+# This is also used to create an EventBridge rule that is run at a
+# fixed cadence with a Lambda target that disables AWS access for
+# inactive users.
 # ------------------------------------------------------------------------------
 
 data "aws_iam_policy_document" "eventbridge" {

--- a/lambda_policy.tf
+++ b/lambda_policy.tf
@@ -1,0 +1,44 @@
+# ------------------------------------------------------------------------------
+# Create the IAM policy that allows all of the Lambda actions
+# necessary to create a Lambda that is run at a fixed cadence to
+# disable AWS access for inactive users.
+# ------------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "lambda" {
+  statement {
+    actions = [
+      "lambda:AddPermission",
+      "lambda:CreateFunction",
+      "lambda:DeleteFunction",
+      "lambda:EnableReplication",
+      "lambda:GetFunction",
+      "lambda:GetFunctionCodeSigningConfig",
+      "lambda:GetPolicy",
+      "lambda:ListVersionsByFunction",
+      "lambda:RemovePermission",
+      "lambda:TagResource",
+      "lambda:UntagResource",
+      "lambda:UpdateFunctionCode",
+      "lambda:UpdateFunctionConfiguration",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:DeleteLogGroup",
+      "logs:DescribeLogGroups",
+      "logs:ListTagsLogGroup",
+      "logs:PutRetentionPolicy",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "lambda" {
+  description = var.lambda_policy_description
+  name        = var.lambda_policy_name
+  policy      = data.aws_iam_policy_document.lambda.json
+}

--- a/provision_role.tf
+++ b/provision_role.tf
@@ -32,3 +32,9 @@ resource "aws_iam_role_policy_attachment" "eventbridge_policy_attachment" {
   policy_arn = aws_iam_policy.eventbridge.arn
   role       = aws_iam_role.provisionaccount_role.name
 }
+
+# This policy allows us to create Lambda functions
+resource "aws_iam_role_policy_attachment" "lambda_policy_attachment" {
+  policy_arn = aws_iam_policy.lambda.arn
+  role       = aws_iam_role.provisionaccount_role.name
+}

--- a/variables.tf
+++ b/variables.tf
@@ -25,14 +25,26 @@ variable "users_account_id" {
 # These parameters have reasonable defaults.
 # ------------------------------------------------------------------------------
 variable "eventbridge_policy_description" {
-  default     = "Allows sufficient permissions to create an EventBridge rule that is triggered whenever a new IAM or SSO user is created, as well as connect a target to that rule, in the new account."
-  description = "The description to associate with the IAM policy that allows sufficient permissions to create an EventBridge rule that is triggered whenever a new IAM or SSO user is created, as well as connect a target to that rule, in the new account."
+  default     = "Allows sufficient permissions to create an EventBridge rule that is triggered whenever a new IAM or SSO user is created, as well as connect a target to that rule, in the new account.  Also alows sufficient permissions to create an EventBridge rule that is run at a fixed cadence with a Lambda target that disables AWS access for inactive users."
+  description = "The description to associate with the IAM policy that allows sufficient permissions to create an EventBridge rule that is triggered whenever a new IAM or SSO user is created, as well as connect a target to that rule, in the new account.  This policy is also used to create an EventBridge rule that is run at a fixed cadence with a Lambda target that disables AWS access for inactive users."
   type        = string
 }
 
 variable "eventbridge_policy_name" {
   default     = "NewUserEventBridgePolicy"
-  description = "The name to assign the IAM policy that allows sufficient permissions to create an EventBridge rule that is triggered whenever a new IAM or SSO user is created, as well as connect a target to that rule, in the new account."
+  description = "The name to assign the IAM policy that allows sufficient permissions to create an EventBridge rule that is triggered whenever a new IAM or SSO user is created, as well as connect a target to that rule, in the new account.  This policy is also used to create an EventBridge rule that is run at a fixed cadence with a Lambda target that disables AWS access for inactive users."
+  type        = string
+}
+
+variable "lambda_policy_description" {
+  default     = "Allows sufficient permissions to create a Lambda function in the new account."
+  description = "The description to associate with the IAM policy that allows sufficient permissions to create a Lambda function in the new account."
+  type        = string
+}
+
+variable "lambda_policy_name" {
+  default     = "LambdaPolicy"
+  description = "The name to assign the IAM policy that allows sufficient permissions to create a Lambda function in the new account."
   type        = string
 }
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds the necessary permissions to apply the [cisagov/disable-inactive-iam-users-tf-module](https://github.com/cisagov/disable-inactive-iam-users-tf-module) module.

See also:
- cisagov/disable-inactive-iam-users-tf-module#1
- cisagov/disable-inactive-iam-users-lambda#1
- cisagov/cool-accounts#147

## 💭 Motivation and context ##

We have a POAM about disabling inactive users in IAM.  Partially resolves cisagov/cool-system-internal#143.

## 🧪 Testing ##

I deployed these changes to our COOL Users account without incident.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.