### PR TITLE
Add `logs:TagLogGroup` permission

### DIFF
--- a/lambda_policy.tf
+++ b/lambda_policy.tf
@@ -31,6 +31,7 @@ data "aws_iam_policy_document" "lambda" {
       "logs:DescribeLogGroups",
       "logs:ListTagsLogGroup",
       "logs:PutRetentionPolicy",
+      "logs:TagLogGroup",
       "logs:TagResource",
     ]
 


### PR DESCRIPTION

# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds the `logs:TagLogGroup` permission to the policy created by this module.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

`logs:TagLogGroup` is needed in order to update tags of previously-deployed log groups, as I recently discovered.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Visual inspection.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

