### PR TITLE
Support multi-environment usage in example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ __pycache__
 .terraform.lock.hcl
 terraform.tfstate
 terraform.tfstate.backup
+*.tfconfig
 *.tfvars

--- a/examples/basic_usage/README.md
+++ b/examples/basic_usage/README.md
@@ -17,16 +17,16 @@ Therefore you must first apply this Terraform code with programmatic
 credentials for AWSAdministratorAccess as obtained for the example
 Pettifogger0 account from the AWS SSO page.
 
-To do this, follow these steps:
+To do this, follow these steps (the steps below use an example environment named
+"dev"; replace "dev" with the name of your environment):
 
-1. Comment out the `profile = "example-pettifogger0-provisionaccount"`
-   line for the "default" provider in `providers.tf` and directly
-   below that uncomment the line `profile =
-   "example-pettifogger0-account-admin"`.
-1. Create a new AWS profile called `example-pettifogger0-account-admin`
-   in your Boto3 configuration using the "AWSAdministratorAccess"
-   credentials (access key ID, secret access key, and session token)
-   as obtained from the example Pettifogger0 account:
+1. Comment out the `profile = "example-pettifogger0-provisionaccount"` line for
+   the "default" provider in `providers.tf` and directly below that uncomment
+   the line `profile = "example-pettifogger0-account-admin"`.
+1. Create a new AWS profile called `example-pettifogger0-account-admin` in your
+   Boto3 configuration using the "AWSAdministratorAccess" credentials (access
+   key ID, secret access key, and session token) as obtained from the example
+   Pettifogger0 account:
 
    ```console
    [example-pettifogger0-account-admin]
@@ -35,25 +35,42 @@ To do this, follow these steps:
    aws_session_token = <MY_SESSION_TOKEN>
    ```
 
-1. Create a Terraform workspace (if you haven't already done so) by running
-   `terraform workspace new <workspace_name>`
-1. Create a `<workspace_name>.tfvars` file with all of the required
-   variables (see [Inputs](#inputs) below for details):
+1. Create a backend configuration file named `dev.tfconfig` containing the name
+   of the S3 bucket where "dev" environment Terraform state is stored - this
+   file is required to initialize the Terraform backend in each environment:
 
-   ```console
-   users_account_id = "222222222222"
-   ```
+    ```hcl
+    bucket = "my-dev-terraform-state-bucket"
+    ```
 
-1. Run the command `terraform init`.
-1. Run the command `terraform apply
-   -var-file=<workspace_name>.tfvars`.
+1. Initialize the Terraform backend for the "dev" environment using your backend
+   configuration file:
+
+    ```console
+    terraform init -upgrade -backend-config=dev.tfconfig
+    ```
+
+    > [!NOTE]
+    > When performing this step for additional environments (i.e. not your first
+    > environment), use the `-reconfigure` flag:
+    >
+    > ```console
+    > terraform init -upgrade -backend-config=other-env.tfconfig -reconfigure
+    > ```
+
+1. Create a Terraform variables file named `dev.tfvars` containing all of the
+   required variables (see [Inputs](#inputs) below for details). For example:
+
+    ```hcl
+    users_account_id = "222222222222"
+    ```
+
+1. Run `terraform apply -var-file=dev.tfvars`.
 1. Revert the changes you made to `providers.tf` in step 1.
-1. Run the command `terraform apply
-    -var-file=<workspace_name>.tfvars`.
+1. Re-run `terraform apply -var-file=dev.tfvars`.
 
-At this point the account has been bootstrapped, and you can apply
-future changes by simply running `terraform apply
--var-file=<workspace_name>.tfvars`.
+At this point the account has been bootstrapped, and you can apply future
+changes by simply re-running `terraform apply -var-file=dev.tfvars`.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements ##

--- a/examples/basic_usage/backend.tf
+++ b/examples/basic_usage/backend.tf
@@ -1,6 +1,10 @@
 terraform {
   backend "s3" {
-    bucket         = "cisa-cool-terraform-state"
+    # Use a partial configuration to avoid hardcoding the bucket name. This
+    # allows the bucket name to be set on a per-environment basis via the
+    # -backend-config command line option or other methods.  For details, see:
+    # https://developer.hashicorp.com/terraform/language/backend#partial-configuration
+    bucket         = ""
     dynamodb_table = "terraform-state-lock"
     encrypt        = true
     key            = "provisionaccount-role-tf-module/examples/basic_usage/terraform.tfstate"


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR updates the example code used to call `cisagov/provisionaccount-read-role-tf-module` to remove a hard-coded bucket name and use a [partial backend configuration](https://developer.hashicorp.com/terraform/language/backend#partial-configuration).  The corresponding documentation is also updated to reflect the changes.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Whenever possible, we strive to remove hard-coded bucket names in our code.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I ran a `terraform plan` in `examples/basic_usage` and verified that the output looked as expected.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
